### PR TITLE
Use bucket policy to provide public read access

### DIFF
--- a/provision/terraform/provider.tf
+++ b/provision/terraform/provider.tf
@@ -1,3 +1,0 @@
-provider "aws" {
-  region = "${var.aws_region}"
-}

--- a/provision/terraform/s3.tf
+++ b/provision/terraform/s3.tf
@@ -1,20 +1,28 @@
 resource "aws_s3_bucket" "shippostbot_s3" {
   bucket = "${var.s3_bucket_name}"
-  acl = "public-read"
+  acl    = "private"
 
   tags = {
-    App = "ShippostBot"
+    App         = "ShippostBot"
     Environment = "Production"
-    Service = "S3"
-    Access = "PublicRead"
+    Service     = "S3"
+    Access      = "PublicRead"
   }
 }
 
 resource "aws_iam_policy" "shippostbot_s3_access_policy" {
-  name = "ShippostBotS3FullAccess"
-  path = "/shippostbot/"
+  name        = "ShippostBotS3FullAccess"
+  path        = "/shippostbot/"
   description = "Policy to allow full access to ShippostBot buckets"
-  policy = "${data.aws_iam_policy_document.shippostbot_s3_access_policy.json}"
+  policy      = "${data.aws_iam_policy_document.shippostbot_s3_access_policy.json}"
+}
+
+data "aws_iam_policy_document" "shippostbot_s3_access_policy" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:*"]
+    resources = ["${aws_s3_bucket.shippostbot_s3.arn}/*"]
+  }
 }
 
 resource "aws_s3_bucket_policy" "shippostbot_s3_policy" {
@@ -22,16 +30,9 @@ resource "aws_s3_bucket_policy" "shippostbot_s3_policy" {
   policy = "${data.aws_iam_policy_document.shippostbot_s3_policy.json}"
 }
 
-data "aws_iam_policy_document" "shippostbot_s3_access_policy" {
-  statement {
-    effect = "Allow"
-    actions = ["s3:*"]
-    resources = ["${aws_s3_bucket.shippostbot_s3.arn}/*"]
-  }
-}
-
 data "aws_iam_policy_document" "shippostbot_s3_policy" {
   statement {
+    sid    = "AllowLambdaFunctions"
     effect = "Allow"
     actions = [
       "s3:GetObject",
@@ -39,8 +40,19 @@ data "aws_iam_policy_document" "shippostbot_s3_policy" {
       "s3:DeleteObject"
     ]
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = ["${aws_iam_role.shippostbot_lambda_role.arn}"]
+    }
+    resources = ["${aws_s3_bucket.shippostbot_s3.arn}/*"]
+  }
+
+  statement {
+    sid     = "AllowPublicRead"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    principals {
+      type        = "*"
+      identifiers = ["*"]
     }
     resources = ["${aws_s3_bucket.shippostbot_s3.arn}/*"]
   }

--- a/provision/terraform/terraform.tf
+++ b/provision/terraform/terraform.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket = "kogane-terraform-states"
+    key    = "shippostbot/terraform.tfstate"
+    region = "ap-southeast-1"
+  }
+}
+
+provider "aws" {
+  region = "${var.aws_region}"
+}


### PR DESCRIPTION
AWS tend to complain when an S3 bucket uses ACL to provide public read access instead of the bucket policy. These changes effectively make the S3 bucket private and use the bucket policy instead of ACL for the public read access permission.